### PR TITLE
Actually check exit status rather than result

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,10 @@ fn run_wasmtime_wasip2(os_args: Vec<OsString>) -> Result<(), Box<dyn std::error:
         .args(args)
         .spawn()
         .expect("failed to execute process");
-    child.wait().expect("command wasn't running");
-    Ok(())
+    let status = child.wait()?;
+    if status.success() {
+      Ok(())
+    } else {
+      Err("process returned failure".into())
+    }
 }


### PR DESCRIPTION
I was noticing a test failure in wasm32-wasip2 builds of grmtools,
however the test wasn't actually failing.  It appears that the `workspace_runner` was sometimes
dropping an exit status, e.g. when we have `Ok(Failure)` the runner only checked the outer `Result`.

This won't fix the actual testsuite failure (which seems like it may be an issue related to filesystem paths) but should fix dropping the exit status.

@ltratt
